### PR TITLE
fix(sw): return 200-299,304 responses immediately

### DIFF
--- a/sw/CacheChildrenStrategy.ts
+++ b/sw/CacheChildrenStrategy.ts
@@ -20,7 +20,7 @@ const CACHE_VERSION = 'v1'
 /**
  * The maximum allowed age of the sw cache in milliseconds.
  */
-const MAX_SW_CACHE_AGE = 1000 * 60 * 5
+// const MAX_SW_CACHE_AGE = 1000 * 60 * 5
 
 // Based on Java's hashCode implementation: https://stackoverflow.com/a/7616484/104380
 const generateHashCode = str => [...str].reduce((hash, chr) => 0 | (31 * hash + chr.charCodeAt(0)), 0)
@@ -44,12 +44,13 @@ function isCachedResponseStillValid (cachedResponse?: Response): cachedResponse 
     return false
   }
 
-  const cachedResponseDate = cachedResponse.headers.get('Date')
-  const cachedResponseAge = cachedResponseDate != null ? Date.now() - new Date(cachedResponseDate).getTime() : Infinity
+  // leaving if we need it, but will remove in PR if preview is good.
+  // const cachedResponseDate = cachedResponse.headers.get('Date')
+  // const cachedResponseAge = cachedResponseDate != null ? Date.now() - new Date(cachedResponseDate).getTime() : Infinity
 
-  if (cachedResponseAge > MAX_SW_CACHE_AGE) {
-    return false
-  }
+  // if (cachedResponseAge > MAX_SW_CACHE_AGE) {
+  //   return false
+  // }
 
   return true
 }


### PR DESCRIPTION
fixes #380

This PR updates the caching strategy to prevent the duplicate call to the backend
if we have a cached call, and returns it immediately.

One thing to note, is that vercel-cached responses return [HTTP 304](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304) responses,
and `response.ok` didn't check for that. This PR also addresses this.

So, a call to the backend vercel function, that calls github does *NOT* happen IFF:

1. There is a cached response
2. That cached response has a status code of 200-299
3. That cached response has a status code of 304;

A backend call to the backend vercel function, that calls github, *WILL* happen IFF:

1. There is *no* cached response
2. The cached response is a failed request (github error, vercel error, etc)
3. The cached response was a modified result.
3. ~~The cached response's max-age is "too old"~~
